### PR TITLE
Fixing creditCardForm example for r10 version 4.1.1

### DIFF
--- a/examples/creditCardForm/elm.json
+++ b/examples/creditCardForm/elm.json
@@ -20,6 +20,7 @@
             "elm-community/json-extra": "4.3.0",
             "elm-community/list-extra": "8.2.4",
             "elm-community/string-extra": "4.0.1",
+            "lucamug/elm-ui-with-context": "1.0.0",
             "mdgriffith/elm-ui": "1.1.8",
             "noahzgordon/elm-color-extra": "1.0.2",
             "zwilias/json-decode-exploration": "6.0.0"

--- a/examples/creditCardForm/src/Main.elm
+++ b/examples/creditCardForm/src/Main.elm
@@ -3,9 +3,9 @@ module Main exposing (main)
 import Browser
 import Color.Convert
 import Color.Manipulate
-import Element exposing (..)
-import Element.Border as Border
-import Element.Font as Font
+import Element.WithContext exposing (..)
+import Element.WithContext.Border as Border
+import Element.WithContext.Font as Font
 import Html
 import Html.Attributes
 import R10.Button
@@ -14,6 +14,7 @@ import R10.Color
 import R10.Color.AttrsBackground
 import R10.Color.Svg
 import R10.Color.Utils
+import R10.Context
 import R10.Form
 import R10.FormTypes
 import R10.Libu
@@ -35,31 +36,40 @@ init =
                 , idDom = Nothing
                 , type_ = R10.FormTypes.inputField.textWithPattern "____ ____ ____ ____"
                 , label = "Card Number"
+                , clickableLabel = False
                 , helperText = Nothing
                 , requiredLabel = requiredLabel
                 , validationSpecs =
                     Just
-                        { showPassedValidationMessages = False
-                        , hidePassedValidationStyle = False
+                        { pretendIsNotValidatedIfValid = True
+                        , showAlsoPassedValidation = False
                         , validationIcon = R10.FormTypes.NoIcon
-                        , validation = [ R10.Form.validation.required ]
+                        , validation =
+                            [ R10.Form.validation.required ]
                         }
+                , minWidth = Nothing
+                , maxWidth = Nothing
+                , autocomplete = Nothing
                 }
             , R10.Form.entity.field
                 { id = "cardHolder"
                 , idDom = Nothing
                 , type_ = R10.FormTypes.inputField.textPlain
                 , label = "Card Holder"
+                , clickableLabel = False
                 , helperText = Nothing
                 , requiredLabel = requiredLabel
                 , validationSpecs =
                     Just
-                        { showPassedValidationMessages = False
-                        , hidePassedValidationStyle = False
+                        { pretendIsNotValidatedIfValid = True
+                        , showAlsoPassedValidation = False
                         , validationIcon = R10.FormTypes.NoIcon
                         , validation =
                             [ R10.Form.validation.required ]
                         }
+                , minWidth = Nothing
+                , maxWidth = Nothing
+                , autocomplete = Nothing
                 }
             , R10.Form.entity.wrappable "wrappable"
                 [ R10.Form.entity.field
@@ -67,30 +77,40 @@ init =
                     , idDom = Nothing
                     , type_ = R10.FormTypes.inputField.textWithPattern "MM/YY"
                     , label = "Expires"
+                    , clickableLabel = False
                     , helperText = Nothing
                     , requiredLabel = requiredLabel
                     , validationSpecs =
                         Just
-                            { showPassedValidationMessages = False
-                            , hidePassedValidationStyle = False
+                            { pretendIsNotValidatedIfValid = True
+                            , showAlsoPassedValidation = False
                             , validationIcon = R10.FormTypes.NoIcon
-                            , validation = [ R10.Form.validation.required ]
+                            , validation =
+                                [ R10.Form.validation.required ]
                             }
+                    , minWidth = Nothing
+                    , maxWidth = Nothing
+                    , autocomplete = Nothing
                     }
                 , R10.Form.entity.field
                     { id = "cvv"
                     , idDom = Nothing
                     , type_ = R10.FormTypes.inputField.textWithPattern "___"
                     , label = "CVV"
+                    , clickableLabel = False
                     , helperText = Nothing
                     , requiredLabel = requiredLabel
                     , validationSpecs =
                         Just
-                            { showPassedValidationMessages = False
-                            , hidePassedValidationStyle = False
+                            { pretendIsNotValidatedIfValid = True
+                            , showAlsoPassedValidation = False
                             , validationIcon = R10.FormTypes.NoIcon
-                            , validation = [ R10.Form.validation.required ]
+                            , validation =
+                                [ R10.Form.validation.required ]
                             }
+                    , minWidth = Nothing
+                    , maxWidth = Nothing
+                    , autocomplete = Nothing
                     }
                 ]
             ]
@@ -117,14 +137,14 @@ update msg model =
                     { form
                         | state =
                             form.state
-                                |> R10.Form.update msgForm
+                                |> R10.Form.update (\_ a -> a) msgForm
                                 |> Tuple.first
                     }
             in
             { model | form = newForm }
 
 
-viewCreditCard : R10.Theme.Theme -> R10.Form.State -> Element msg
+viewCreditCard : R10.Theme.Theme -> R10.Form.State -> Element context msg
 viewCreditCard theme formState =
     let
         logo : { height : number, src : String }
@@ -185,9 +205,14 @@ viewCreditCard theme formState =
         ]
 
 
+context : R10.Context.Context
+context =
+    R10.Context.empty
+
+
 view : R10.Theme.Theme -> Model -> Html.Html Msg
 view theme model =
-    layoutWith
+    layoutWith { context | theme = theme }
         { options =
             [ focusStyle
                 { borderColor = Nothing
@@ -196,18 +221,17 @@ view theme model =
                 }
             ]
         }
-        [ R10.Color.AttrsBackground.background theme
+        [ R10.Color.AttrsBackground.background
         , padding 50
         ]
-    <|
-        column
+        (column
             (R10.Card.high theme
                 ++ [ centerX
                    , centerY
                    , width (fill |> maximum 460)
                    , height shrink
                    , spacing 30
-                   , R10.Color.AttrsBackground.surface2dp theme
+                   , R10.Color.AttrsBackground.surface2dp
                    ]
             )
             [ R10.Svg.LogosExtra.r10 [ centerX ] (R10.Color.Svg.logo theme) 32
@@ -220,13 +244,13 @@ view theme model =
                     , style = R10.Form.style.outlined
                     , palette = Just <| R10.Form.themeToPalette theme
                     }
-            , Element.map MsgForm <|
+            , Element.WithContext.map MsgForm <|
                 R10.Button.primary []
                     { label = text "Submit"
                     , libu = R10.Libu.Bu <| Just <| R10.Form.msg.submit model.form.conf
-                    , theme = theme
                     }
             ]
+        )
 
 
 
@@ -260,7 +284,7 @@ requiredLabel =
     Nothing
 
 
-textCreditCard : List (Attribute msg) -> String -> Element msg
+textCreditCard : List (Attr context () msg) -> String -> Element context msg
 textCreditCard attrs string =
     el
         ([ Font.size 13
@@ -275,7 +299,7 @@ textCreditCard attrs string =
         text string
 
 
-textEmbossedCreditCard : List (Attribute msg) -> String -> Element msg
+textEmbossedCreditCard : List (Attribute context msg) -> String -> Element context msg
 textEmbossedCreditCard attrs string =
     let
         shadow : Int -> Int -> String -> String
@@ -311,7 +335,7 @@ textEmbossedCreditCard attrs string =
         (text string)
 
 
-embossedValue : R10.Form.State -> List (Attribute msg) -> R10.Form.KeyAsString -> String -> Element msg
+embossedValue : R10.Form.State -> List (Attribute context msg) -> R10.Form.KeyAsString -> String -> Element context msg
 embossedValue formState attrs id default =
     let
         defaultIfEmpty : String -> String

--- a/examples/creditCardForm/src/Main2.elm
+++ b/examples/creditCardForm/src/Main2.elm
@@ -1,10 +1,9 @@
 module Main2 exposing (main)
 
 import Browser
-import Element exposing (..)
-import Element.Background as Background
-import Element.Border as Border
-import Element.Font as Font
+import Element.WithContext exposing (..)
+import Element.WithContext.Border as Border
+import Element.WithContext.Font as Font
 import Html
 import Html.Attributes
 import R10.Button
@@ -12,16 +11,13 @@ import R10.Card
 import R10.Color
 import R10.Color.AttrsBackground
 import R10.Color.Svg
+import R10.Context
 import R10.FontSize
 import R10.Form
-import R10.Form.Internal.Key
 import R10.FormTypes
-import R10.Language
 import R10.Libu
 import R10.Mode
-import R10.Paragraph
 import R10.Svg.Logos
-import R10.Svg.LogosExtra
 import R10.Theme
 
 
@@ -64,31 +60,40 @@ init =
                 , idDom = Nothing
                 , type_ = R10.FormTypes.TypeText (R10.FormTypes.TextWithPattern "____ ____ ____ ____")
                 , label = "Card Number"
+                , clickableLabel = False
                 , helperText = Nothing
                 , requiredLabel = requiredLabel
                 , validationSpecs =
                     Just
-                        { showPassedValidationMessages = False
-                        , hidePassedValidationStyle = False
+                        { pretendIsNotValidatedIfValid = True
+                        , showAlsoPassedValidation = False
                         , validationIcon = R10.FormTypes.NoIcon
-                        , validation = [ R10.Form.validation.required ]
+                        , validation =
+                            [ R10.Form.validation.required ]
                         }
+                , minWidth = Nothing
+                , maxWidth = Nothing
+                , autocomplete = Nothing
                 }
             , R10.Form.entity.field
                 { id = "cardHolder"
                 , idDom = Nothing
                 , type_ = R10.FormTypes.TypeText R10.FormTypes.TextPlain
                 , label = "Card Holder"
+                , clickableLabel = False
                 , helperText = Nothing
                 , requiredLabel = requiredLabel
                 , validationSpecs =
                     Just
-                        { showPassedValidationMessages = False
-                        , hidePassedValidationStyle = False
+                        { pretendIsNotValidatedIfValid = True
+                        , showAlsoPassedValidation = False
                         , validationIcon = R10.FormTypes.NoIcon
                         , validation =
                             [ R10.Form.validation.required ]
                         }
+                , minWidth = Nothing
+                , maxWidth = Nothing
+                , autocomplete = Nothing
                 }
             , R10.Form.entity.wrappable "wrappable"
                 [ R10.Form.entity.field
@@ -96,30 +101,40 @@ init =
                     , idDom = Nothing
                     , type_ = R10.FormTypes.TypeText (R10.FormTypes.TextWithPattern "MM/YY")
                     , label = "Expires"
+                    , clickableLabel = False
                     , helperText = Nothing
                     , requiredLabel = requiredLabel
                     , validationSpecs =
                         Just
-                            { showPassedValidationMessages = False
-                            , hidePassedValidationStyle = False
+                            { pretendIsNotValidatedIfValid = True
+                            , showAlsoPassedValidation = False
                             , validationIcon = R10.FormTypes.NoIcon
-                            , validation = [ R10.Form.validation.required ]
+                            , validation =
+                                [ R10.Form.validation.required ]
                             }
+                    , minWidth = Nothing
+                    , maxWidth = Nothing
+                    , autocomplete = Nothing
                     }
                 , R10.Form.entity.field
                     { id = "cvv"
                     , idDom = Nothing
                     , type_ = R10.FormTypes.TypeText (R10.FormTypes.TextWithPattern "___")
                     , label = "CVV"
+                    , clickableLabel = False
                     , helperText = Nothing
                     , requiredLabel = requiredLabel
                     , validationSpecs =
                         Just
-                            { showPassedValidationMessages = False
-                            , hidePassedValidationStyle = False
+                            { pretendIsNotValidatedIfValid = True
+                            , showAlsoPassedValidation = False
                             , validationIcon = R10.FormTypes.NoIcon
-                            , validation = [ R10.Form.validation.required ]
+                            , validation =
+                                [ R10.Form.validation.required ]
                             }
+                    , minWidth = Nothing
+                    , maxWidth = Nothing
+                    , autocomplete = Nothing
                     }
                 ]
             ]
@@ -142,14 +157,14 @@ update msg model =
                     { form
                         | state =
                             form.state
-                                |> R10.Form.update msgForm
+                                |> R10.Form.update (\_ a -> a) msgForm
                                 |> Tuple.first
                     }
             in
             { model | form = newForm }
 
 
-viewCreditCard : R10.Form.State -> Element msg
+viewCreditCard : R10.Form.State -> Element context msg
 viewCreditCard formState =
     let
         logo =
@@ -186,9 +201,20 @@ viewCreditCard formState =
         ]
 
 
+context : R10.Context.Context
+context =
+    R10.Context.empty
+
+
 view : Model -> Html.Html Msg
 view model =
     layoutWith
+        { context
+            | theme =
+                { mode = R10.Mode.Light
+                , primaryColor = R10.Color.primary.blueSky
+                }
+        }
         { options =
             [ focusStyle
                 { borderColor = Nothing
@@ -197,7 +223,7 @@ view model =
                 }
             ]
         }
-        [ R10.Color.AttrsBackground.background theme, padding 20, R10.FontSize.normal ]
+        [ R10.Color.AttrsBackground.background, padding 20, R10.FontSize.normal ]
         (column
             (R10.Card.high theme
                 ++ [ centerX
@@ -217,11 +243,10 @@ view model =
                     , style = R10.Form.style.filled
                     , palette = Just <| R10.Form.themeToPalette theme
                     }
-            , Element.map MsgForm <|
+            , Element.WithContext.map MsgForm <|
                 R10.Button.primary []
                     { label = text "Submit"
                     , libu = R10.Libu.Bu <| Just <| R10.Form.msg.submit model.form.conf
-                    , theme = theme
                     }
             ]
         )
@@ -258,7 +283,7 @@ requiredLabel =
     Nothing
 
 
-textCreditCard : List (Attribute msg) -> String -> Element msg
+textCreditCard : List (Attribute context msg) -> String -> Element context msg
 textCreditCard attrs string =
     el
         ([ Font.size 13
@@ -271,7 +296,7 @@ textCreditCard attrs string =
         text string
 
 
-textEmbossedCreditCard : List (Attribute msg) -> String -> Element msg
+textEmbossedCreditCard : List (Attribute context msg) -> String -> Element context msg
 textEmbossedCreditCard attrs string =
     let
         shadow : Int -> Int -> String -> String
@@ -311,7 +336,7 @@ textEmbossedCreditCard attrs string =
         (text string)
 
 
-embossedValue : R10.Form.State -> List (Attribute msg) -> R10.Form.KeyAsString -> String -> Element msg
+embossedValue : R10.Form.State -> List (Attribute context msg) -> R10.Form.KeyAsString -> String -> Element context msg
 embossedValue formState attrs id default =
     let
         defaultIfEmpty : String -> String

--- a/examples/creditCardForm/src/Main3.elm
+++ b/examples/creditCardForm/src/Main3.elm
@@ -1,10 +1,10 @@
 module Main3 exposing (main)
 
 import Browser
-import Element exposing (..)
-import Element.Background as Background
-import Element.Border as Border
-import Element.Font as Font
+import Element.WithContext exposing (..)
+import Element.WithContext.Background as Background
+import Element.WithContext.Border as Border
+import Element.WithContext.Font as Font
 import Html
 import Html.Attributes
 import R10.Button
@@ -12,16 +12,13 @@ import R10.Card
 import R10.Color
 import R10.Color.AttrsBackground
 import R10.Color.Svg
+import R10.Context
 import R10.FontSize
 import R10.Form
-import R10.Form.Internal.Key
 import R10.FormTypes
-import R10.Language
 import R10.Libu
 import R10.Mode
-import R10.Paragraph
 import R10.Svg.Logos
-import R10.Svg.LogosExtra
 import R10.Theme
 
 
@@ -64,61 +61,80 @@ init =
                 , idDom = Nothing
                 , type_ = R10.FormTypes.TypeText (R10.FormTypes.TextWithPattern "____ ____ ____ ____")
                 , label = "Card Number"
+                , clickableLabel = False
                 , helperText = Nothing
                 , requiredLabel = requiredLabel
                 , validationSpecs =
                     Just
-                        { showPassedValidationMessages = False
-                        , hidePassedValidationStyle = False
+                        { pretendIsNotValidatedIfValid = True
+                        , showAlsoPassedValidation = False
                         , validationIcon = R10.FormTypes.NoIcon
-                        , validation = [ R10.Form.validation.required ]
+                        , validation =
+                            [ R10.Form.validation.required ]
                         }
+                , minWidth = Nothing
+                , maxWidth = Nothing
+                , autocomplete = Nothing
                 }
             , R10.Form.entity.field
                 { id = "cardHolder"
                 , idDom = Nothing
                 , type_ = R10.FormTypes.TypeText R10.FormTypes.TextPlain
                 , label = "Card Holder"
+                , clickableLabel = False
                 , helperText = Nothing
                 , requiredLabel = requiredLabel
                 , validationSpecs =
                     Just
-                        { showPassedValidationMessages = False
-                        , hidePassedValidationStyle = False
+                        { pretendIsNotValidatedIfValid = True
+                        , showAlsoPassedValidation = False
                         , validationIcon = R10.FormTypes.NoIcon
                         , validation =
                             [ R10.Form.validation.required ]
                         }
+                , minWidth = Nothing
+                , maxWidth = Nothing
+                , autocomplete = Nothing
                 }
             , R10.Form.entity.field
                 { id = "expires"
                 , idDom = Nothing
                 , type_ = R10.FormTypes.TypeText (R10.FormTypes.TextWithPattern "MM/YY")
                 , label = "Expires (MM/YY)"
+                , clickableLabel = False
                 , helperText = Nothing
                 , requiredLabel = requiredLabel
                 , validationSpecs =
                     Just
-                        { showPassedValidationMessages = False
-                        , hidePassedValidationStyle = False
+                        { pretendIsNotValidatedIfValid = True
+                        , showAlsoPassedValidation = False
                         , validationIcon = R10.FormTypes.NoIcon
-                        , validation = [ R10.Form.validation.required ]
+                        , validation =
+                            [ R10.Form.validation.required ]
                         }
+                , minWidth = Nothing
+                , maxWidth = Nothing
+                , autocomplete = Nothing
                 }
             , R10.Form.entity.field
                 { id = "cvv"
                 , idDom = Nothing
                 , type_ = R10.FormTypes.TypeText (R10.FormTypes.TextWithPattern "___")
                 , label = "CVV"
+                , clickableLabel = False
                 , helperText = Nothing
                 , requiredLabel = requiredLabel
                 , validationSpecs =
                     Just
-                        { showPassedValidationMessages = False
-                        , hidePassedValidationStyle = False
+                        { pretendIsNotValidatedIfValid = True
+                        , showAlsoPassedValidation = False
                         , validationIcon = R10.FormTypes.NoIcon
-                        , validation = [ R10.Form.validation.required ]
+                        , validation =
+                            [ R10.Form.validation.required ]
                         }
+                , minWidth = Nothing
+                , maxWidth = Nothing
+                , autocomplete = Nothing
                 }
             ]
         , state = R10.Form.initState
@@ -140,14 +156,14 @@ update msg model =
                     { form
                         | state =
                             form.state
-                                |> R10.Form.update msgForm
+                                |> R10.Form.update (\_ a -> a) msgForm
                                 |> Tuple.first
                     }
             in
             { model | form = newForm }
 
 
-viewCreditCard : R10.Form.State -> Element msg
+viewCreditCard : R10.Form.State -> Element context msg
 viewCreditCard formState =
     let
         logo =
@@ -186,9 +202,20 @@ viewCreditCard formState =
         ]
 
 
+context : R10.Context.Context
+context =
+    R10.Context.empty
+
+
 view : Model -> Html.Html Msg
 view model =
     layoutWith
+        { context
+            | theme =
+                { mode = R10.Mode.Light
+                , primaryColor = R10.Color.primary.blueSky
+                }
+        }
         { options =
             [ focusStyle
                 { borderColor = Nothing
@@ -197,7 +224,7 @@ view model =
                 }
             ]
         }
-        [ R10.Color.AttrsBackground.background theme, padding 20, R10.FontSize.normal ]
+        [ R10.Color.AttrsBackground.background, padding 20, R10.FontSize.normal ]
         (column
             (R10.Card.high theme
                 ++ [ centerX
@@ -217,11 +244,10 @@ view model =
                     , style = R10.Form.style.filled
                     , palette = Just <| R10.Form.themeToPalette theme
                     }
-            , Element.map MsgForm <|
+            , Element.WithContext.map MsgForm <|
                 R10.Button.primary []
                     { label = text "Submit"
                     , libu = R10.Libu.Bu <| Just <| R10.Form.msg.submit model.form.conf
-                    , theme = theme
                     }
             ]
         )
@@ -258,7 +284,7 @@ requiredLabel =
     Nothing
 
 
-textCreditCard : List (Attribute msg) -> String -> Element msg
+textCreditCard : List (Attribute context msg) -> String -> Element context msg
 textCreditCard attrs string =
     el
         ([ Font.size 13
@@ -272,7 +298,7 @@ textCreditCard attrs string =
         text string
 
 
-textEmbossedCreditCard : List (Attribute msg) -> String -> Element msg
+textEmbossedCreditCard : List (Attribute context msg) -> String -> Element context msg
 textEmbossedCreditCard attrs string =
     let
         shadow x y color =
@@ -310,7 +336,7 @@ textEmbossedCreditCard attrs string =
         (text string)
 
 
-embossedValue : R10.Form.State -> List (Attribute msg) -> R10.Form.KeyAsString -> String -> Element msg
+embossedValue : R10.Form.State -> List (Attribute context msg) -> R10.Form.KeyAsString -> String -> Element context msg
 embossedValue formState attrs id default =
     let
         defaultIfEmpty : String -> String


### PR DESCRIPTION
Just a minor update for the creditCardForm example for working for v4.1.1 using Elm UI with context.