### PR TITLE
Fix internal Table form update for using R10 version 4.1.1

### DIFF
--- a/src/R10/Table/Internal/Update.elm
+++ b/src/R10/Table/Internal/Update.elm
@@ -108,7 +108,7 @@ justUpdateForm formMsg filtersState =
         Just ( key, form ) ->
             let
                 ( newFormState_, formCmd ) =
-                    R10.Form.update formMsg form.state
+                    R10.Form.update (\_ a -> a) formMsg form.state
             in
             ( { filtersState
                 | filterEditor =


### PR DESCRIPTION
A minor syntax error fix for the old Table with version 3.0.0 to the new version 4.1.1 using the new Form.update